### PR TITLE
Select only the constants that are actually Errors

### DIFF
--- a/lib/zero_mq/errors.rb
+++ b/lib/zero_mq/errors.rb
@@ -1,6 +1,7 @@
 module ZeroMQ
   module Errors
     ERRORS = Errno.constants.map(&Errno.method(:const_get)).
+             select { |obj| obj.is_a?(Class) && obj < SystemCallError }.
              inject({}) { |map, error| map[error.const_get(:Errno)] = error; map }
 
     private


### PR DESCRIPTION
On Rubinius, there are a few other constants that end up under the Errno namespace (other than the myriad SystemCallError classes).

Ironically, one of these is Errno::Mapping, which ironically is there to serve the same purpose as the hash you're constructing here.

Anyway, adding this line will prevent the other constants from ending up in the inject block and raising an exception on Rubinius.
